### PR TITLE
Link tags in post list

### DIFF
--- a/src/app/(list)/post-item.tsx
+++ b/src/app/(list)/post-item.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 
 import { MDX } from '@/comps/mdx/mdx'
 import { PostTag } from '@/comps/post-tag'
+import { TagLink } from '@/comps/tag-link'
 import { getPost } from '@/lib/blog'
 
 type Props = {
@@ -32,7 +33,9 @@ export async function PostItem({ slug }: Props) {
             </span>
           </div>
           {post.tags.map((tag) => (
-            <PostTag key={tag} slug={tag} size="smol" />
+            <TagLink key={tag} href={`/tag/${tag}`} dim>
+              <PostTag slug={tag} size="smol" />
+            </TagLink>
           ))}
         </div>
         <h3 className="mt-1 text-balance font-display font-medium leading-snug">


### PR DESCRIPTION
I think the little tags in the post list should also link their respective tag pages, aka allow me to filter by this tag.

I'm sorry, but I have only coded this up in the Github web editor so I can't promise that it works. :D 